### PR TITLE
Added Applicative and Functor instances to RenderState s

### DIFF
--- a/Tools/StatePlot.hs
+++ b/Tools/StatePlot.hs
@@ -84,7 +84,7 @@ data RenderConfiguration = RenderConf {
 
 data TickSize = LargeTick | SmallTick
 
-newtype RenderState s a = RenderState { runRenderState :: StateT s C.Render a } deriving (Monad, MonadState s)
+newtype RenderState s a = RenderState { runRenderState :: StateT s C.Render a } deriving (Functor,Applicative,Monad, MonadState s)
 
 type CProgram = (Double, Double) -> C.Render ()
 


### PR DESCRIPTION
To compile after AMP all monads need to be applicatives and functors. This patch adds those
two instances where they are missing.