### PR TITLE
Fix build by not requiring the broken Tools.SPlotTest module

### DIFF
--- a/splot.cabal
+++ b/splot.cabal
@@ -29,6 +29,6 @@ executable splot
 
   Build-Depends: cairo, bytestring, bytestring-lexing == 0.5.*, strptime >= 0.1.7, time, 
                  containers, colour, mtl, HUnit, template-haskell, vcs-revision >= 0.0.2
-  Other-Modules: Tools.ColorMap Tools.SPlotTest Tools.SPlotTest Tools.StatePlot
+  Other-Modules: Tools.ColorMap Tools.StatePlot Paths_splot
   Main-Is: Tools/SPlotMain.hs
   Ghc-Options: -O2 -rtsopts


### PR DESCRIPTION
This fixes the build by not requiring the broken `Tools.SPlotTest` module.

Also include `Paths_splot` to fix a cabal warning.